### PR TITLE
3 when username is provided instead of id in config file script does not fail as it should

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+snipeit/__pycache__/

--- a/snipeit/README.md
+++ b/snipeit/README.md
@@ -35,10 +35,17 @@ as such, may not fit for other needs.
     make install
     ```
 
-4. Customize the configuration:
+1. Customize the configuration:
 
    - Open `~/.osfv/snipeit.yml` and provide your Snipe-IT API URL, API token,
      and user ID
+   - `api_url` - typically should be left unchanged, please make sure you have
+     correct DNS configuration or entry in `/etc/hosts`,
+	 - `api_token` - login to Snipe-IT, click on user icon, choose `Manage API
+     Keys`, click `Create New Token`, use name `osfv-scripts`, use generated API
+     token in config file
+   - `user_id` is your Snipe-IT user id, which can be found by going to
+     http://snipeit/users and showing column ID
 
 ## Usage
 

--- a/snipeit/snipeit.py
+++ b/snipeit/snipeit.py
@@ -163,7 +163,7 @@ def check_out_asset(asset_id):
     }
     response = requests.post(f'{api_url}/hardware/{asset_id}/checkout', headers=headers, json=data, timeout=10)
 
-    if response.status_code == 200:
+    if response.status_code == 200 and response.json().get('status') != 'error':
         print(f'Asset {asset_id} successfully checked out to {user_id} user.')
     else:
         print(f'Error checking out asset {asset_id} to user {user_id}. Status code: {response.status_code}')

--- a/snipeit/snipeit.py
+++ b/snipeit/snipeit.py
@@ -28,6 +28,8 @@ def load_api_config():
 
     if not api_url or not api_token:
         raise ValueError('Incomplete API configuration in the YAML file')
+    if not isinstance(user_id, int):
+        raise ValueError(f'User ID configuration in the YAML file should be int: {user_id}')
 
     return api_url, api_token, user_id
 

--- a/snipeit/snipeit.py
+++ b/snipeit/snipeit.py
@@ -173,7 +173,7 @@ def check_out_asset(asset_id):
 def check_in_asset(asset_id):
     response = requests.post(f'{api_url}/hardware/{asset_id}/checkin', headers=headers, timeout=10)
 
-    if response.status_code == 200:
+    if response.status_code == 200 and response.json().get('status') != 'error':
         print(f'Asset {asset_id} successfully checked in.')
     else:
         print(f'Error checking in asset {asset_id}. Status code: {response.status_code}')


### PR DESCRIPTION
Invalid user name:

```shell
(venv) [23:50:25] user:snipeit git:(3-when-username-is-provided-instead-of-id-in-config-file-script-does-not-fail-as-it-should*) $ ./snipeit.py check_out --asset_id 317
Please check the /home/user/.osfv/snipeit.yml file: User ID configuration in the YAML file should be int: pkrol
(venv) [23:50:51] user:snipeit git:(3-when-username-is-provided-instead-of-id-in-config-file-script-does-not-fail-as-it-should*) $ ./snipeit.py check_out --asset_id 317
Asset 317 successfully checked out to 3 user.
```

Checkout with invalid user:

```shell
(venv) [23:49:44] user:snipeit git:(tmp*) $ ./snipeit.py check_out --asset_id 317
Error checking out asset 317 to user pkrol. Status code: 200                                                                                                                                                       
{'status': 'error', 'messages': 'Checkout target for asset Protectli VP2410_1 is invalid - user does not exist.', 'payload': {'asset': {'id': 317, 'asset_tag': 'Protectli VP2410_1'}, 'target_id': 'pkrol', 'targe
t_type': 'user'}}     
```

Check in of not existing asset:

```shell
(venv) [0:08:28] user:osfv-scripts git:(3-when-username-is-provided-instead-of-id-in-config-file-script-does-not-fail-as-it-should*) $ ./snipeit/snipeit.py check_in --asset_id 31723423
Error checking in asset 31723423. Status code: 200
{'status': 'error', 'messages': 'Asset not found', 'payload': None}
```