### PR TITLE
Msi models

### DIFF
--- a/osfv_cli/README.md
+++ b/osfv_cli/README.md
@@ -54,49 +54,52 @@ as such, may not fit for other needs.
      - `user_id` is your Snipe-IT user id, which can be found by going to
        <http://snipeit/users> and showing column ID
 
-To use the script, you can run it with different commands and options. Here are
-some examples:
+To use the script, you can run it with different commands and options. The full
+list of commands and description of arguments is in the help message. Here are
+just some examples.
+
+### snipeit command
 
 * List all used assets:
 
   ```shell
-  osfv_cli list_used
+  osfv_cli snipeit list_used
   ```
 
 * List all unused assets:
 
   ```shell
-  osfv_cli list_unused
+  osfv_cli snipeit list_unused
   ```
 
 * List all assets:
 
   ```shell
-  osfv_cli list_all
+  osfv_cli snipeit list_all
   ```
 
 * Check out an asset (by asset ID):
 
   ```shell
-  osfv_cli check_out --asset_id 123
+  osfv_cli snipeit check_out --asset_id 123
   ```
 
 * Check in an asset (by asset ID):
 
   ```shell
-  osfv_cli check_in --asset_id 123
+  osfv_cli snipeit check_in --asset_id 123
   ```
 
 * Check out an asset (by RTE IP):
 
   ```bash
-  osfv_cli check_out --rte_ip <rte_ip_address>
+  osfv_cli snipeit check_out --rte_ip <rte_ip_address>
   ```
 
 * Check out an asset (by RTE IP):
 
   ```bash
-  osfv_cli check_out --rte_ip <rte_ip_address>
+  osfv_cli snipeit check_out --rte_ip <rte_ip_address>
   ```
 
   > Replace `<rte_ip_address>` with the actual RTE IP address of the asset you
@@ -105,11 +108,80 @@ some examples:
   > Please note that the RTE IP should match the value stored in the asset's
   > custom field named "RTE IP".
 
-* For more command options, you can use the `--help` flag:
+### sonoff command
 
-  ```shell
-  osfv_cli --help
+* Get Sonoff state:
+
+  ```bash
+  osfv_cli sonoff --sonoff_ip <sonoff_ip_address> get
   ```
+
+* Set Sonoff state to ON:
+
+  ```bash
+  osfv_cli sonoff --sonoff_ip <sonoff_ip_address> on
+  ```
+
+* Set Sonoff state to OFF:
+
+  ```bash
+  osfv_cli sonoff --sonoff_ip <sonoff_ip_address> off
+  ```
+
+* Toggle Sonoff state:
+
+  ```bash
+  osfv_cli sonoff --sonoff_ip <sonoff_ip_address> tgl
+  ```
+
+  > Replace `<sonoff_ip_address>` with the IP address of correct Sonoff. You
+  > may also use `--rte_ip` instead, and Sonoff IP will be retrieved from
+  > Snipe-IT if found.
+
+### rte command
+
+* Toggle relay state:
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> rel tgl
+  ```
+
+* Power on the platform (push power button)
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> pwr on
+  ```
+
+* List state of controllable GPIOs:
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> gpio list
+  ```
+
+* Enable SPI lines:
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> spi on
+  ```
+
+* Connect to DUT serial port connected  to RTE via telnet:
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> serial
+  ```
+
+* Flash DUT with given firmware file:
+
+  > flash commands already take care of getting the platform in the correct
+  > power state, and setting correct flashing parameters for certain device model,
+  > as defined in the config files in `osfv_cli/models`
+
+  ```bash
+  osfv_cli rte --rte_ip <rte_ip_address> flash write --rom <path_to_fw_file>
+  ```
+
+  > Replace `<rte_ip_address>` with the actual RTE IP address connected with
+  > the DUT.
 
 ## Adding new platform configs
 

--- a/osfv_cli/cli.yml
+++ b/osfv_cli/cli.yml
@@ -1,2 +1,0 @@
----
-models_dir: MODELS_DIR

--- a/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR4.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR4.yml
@@ -1,0 +1,8 @@
+---
+flash_chip:
+  voltage: "1.8V"
+
+pwr_ctrl:
+  sonoff: true
+  relay: false
+  init_on: false

--- a/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR5.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR5.yml
@@ -1,0 +1,8 @@
+---
+flash_chip:
+  voltage: "1.8V"
+
+pwr_ctrl:
+  sonoff: true
+  relay: false
+  init_on: false

--- a/osfv_cli/osfv_cli/models/MSI PRO Z790-P WIFI DDR5.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z790-P WIFI DDR5.yml
@@ -1,0 +1,8 @@
+---
+flash_chip:
+  voltage: "1.8V"
+
+pwr_ctrl:
+  sonoff: true
+  relay: false
+  init_on: false

--- a/osfv_cli/osfv_cli/osfv_cli.py
+++ b/osfv_cli/osfv_cli/osfv_cli.py
@@ -62,7 +62,7 @@ def list_my_assets(snipeit_api):
         for asset in my_assets:
             print_asset_details(asset)
     else:
-        print("No unused assets found.")
+        print("No used assets found.")
 
 
 # List unused assets

--- a/osfv_cli/osfv_cli/rte.py
+++ b/osfv_cli/osfv_cli/rte.py
@@ -69,7 +69,7 @@ class RTE(rtectrl):
         self.gpio_set(self.GPIO_POWER, "low", sleep)
         time.sleep(sleep)
 
-    def power_off(self, sleep=5):
+    def power_off(self, sleep=6):
         self.gpio_set(self.GPIO_POWER, "low", sleep)
         time.sleep(sleep)
 
@@ -89,6 +89,7 @@ class RTE(rtectrl):
         self.gpio_set(self.GPIO_CMOS, "high-z")
 
     def spi_enable(self):
+        voltage = None
         if "flash_chip" in self.dut_data:
             if "voltage" in self.dut_data["flash_chip"]:
                 voltage = self.dut_data["flash_chip"]["voltage"]
@@ -107,7 +108,7 @@ class RTE(rtectrl):
         self.gpio_set(self.GPIO_SPI_VCC, "low")
         time.sleep(2)
         self.gpio_set(self.GPIO_SPI_ON, "low")
-        time.sleep(2)
+        time.sleep(10)
 
     def spi_disable(self):
         self.gpio_set(self.GPIO_SPI_VCC, "high-z")
@@ -151,7 +152,9 @@ class RTE(rtectrl):
 
         # 3. RTE POFF
         # 4. sleep 3
-        self.power_off(3)
+        # Run 5 times in the loop to make sure to charge from PSU is dissipated
+        for _ in range(5):
+            self.power_off(3)
 
         # 5. SPI ON
         # 6. sleep 2

--- a/osfv_cli/osfv_cli/sonoff_api.py
+++ b/osfv_cli/osfv_cli/sonoff_api.py
@@ -21,14 +21,14 @@ class SonoffDevice:
         return response.status_code
 
     def turn_on(self):
-        endpoint = "/switch/sonoff_s20_relay/turn_on"
+        endpoint = "/cm?cmnd=Power%20On"
         return self._post_request(endpoint)
 
     def turn_off(self):
-        endpoint = "/switch/sonoff_s20_relay/turn_off"
+        endpoint = "/cm?cmnd=Power%20Off"
         return self._post_request(endpoint)
 
     def get_state(self):
-        endpoint = "/switch/sonoff_s20_relay"
+        endpoint = "/cm?cmnd=Power"
         response = self._get_request(endpoint)
-        return response.get("state")
+        return response.get("POWER")


### PR DESCRIPTION
Can flash the board with:


```
osfv_cli rte --rte_ip 192.168.10.107 flash write --rom ~/Downloads/msi_ms7d25_v1.1.3_ddr4.rom 
DUT model retrieved from snipeit: MSI PRO Z690-A DDR4
Sonoff init
Writing /home/macpijan/Downloads/msi_ms7d25_v1.1.3_ddr4.rom to flash...
Executing command: flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000  -w /tmp/write.rom
flashrom v1.2 on Linux 5.4.69 (armv7l)
flashrom is free software, get the source code at https://flashrom.org

Using clock_gettime for delay loops (clk_id: 1, resolution: 1ns).

Found Macronix flash chip "MX25U25635F" (32768 kB, SPI) on linux_spi.

===
This flash part has status UNTESTED for operations: ERASE WRITE
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
Thanks for your help!

Reading old flash chip contents... 
done.
Erasing and writing flash chip... 
Erase/write done.

Verifying flash... 
VERIFIED.


Flash written
```

It is flashing the whole chip, as in other platforms, but in MSI scripts on RTEs we had:

```
echo "start flash command"
flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000 \
        --layout msi_z690a.layout -i bios -w $1
```