### PR TITLE
osfv_cli/models/minnowmax.yml: wip

### DIFF
--- a/osfv_cli/osfv_cli/models/minnowmax.yml
+++ b/osfv_cli/osfv_cli/models/minnowmax.yml
@@ -1,0 +1,14 @@
+---
+flash_chip:
+  model: "W25Q64JV-.Q"
+  voltage: "3.3V"
+
+programmer:
+  name: rte_1_1
+
+pwr_ctrl:
+  sonoff: false
+  relay: true
+  init_on: false
+
+reset_cmos: false


### PR DESCRIPTION
Not tested.

Can be tested via:

osfv_cli rte --rte_ip 192.168.10.198 --model minnowmax flash probe