### PR TITLE
osfv_cli/models/Optiplex 7010.yml: add

### DIFF
--- a/osfv_cli/osfv_cli/models/Optiplex 7010.yml
+++ b/osfv_cli/osfv_cli/models/Optiplex 7010.yml
@@ -1,0 +1,20 @@
+---
+flash_chip:
+  # flash chip model to be used by flashrom (optional - if not given, no chip
+  # parameter will be explicitelt added to flashrom)
+  model: "MX25L3205D/MX25L3208D"
+    # flash chip voltage (required)
+  voltage: "3.3V"
+
+programmer:
+  name: rte_1_1
+
+pwr_ctrl:
+  # whether power is controlled via Sonoff plug (required)
+  sonoff: true
+  # whether power is controller via on-board RTE relay (required)
+  relay: false
+  init_on: false
+
+# whether CMOS reset is required after flashing (optional - defaults to false)
+reset_cmos: false


### PR DESCRIPTION
Chip was detected correctly:

```
osfv_cli rte --rte_ip 192.168.10.225 flash probe 
DUT model retrieved from snipeit: Optiplex 7010
Probing flash...
Executing command: flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000 -c MX25L3205D/MX25L3208D
flashrom v1.0 on Linux 4.18.10 (armv7l)

flashrom is free software, get the source code at https://flashrom.org


Using clock_gettime for delay loops (clk_id: 1, resolution: 1ns).
Found Macronix flash chip "MX25L3205D/MX25L3208D" (4096 kB, SPI) on linux_spi.

No operations were specified.

```