### PR TITLE
osfv_cli: introduce flash power state param

### DIFF
--- a/osfv_cli/osfv_cli/models/APU2.yml
+++ b/osfv_cli/osfv_cli/models/APU2.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/APU3.yml
+++ b/osfv_cli/osfv_cli/models/APU3.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/APU4.yml
+++ b/osfv_cli/osfv_cli/models/APU4.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/APU5.yml
+++ b/osfv_cli/osfv_cli/models/APU5.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/APU6.yml
+++ b/osfv_cli/osfv_cli/models/APU6.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/APU7.yml
+++ b/osfv_cli/osfv_cli/models/APU7.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/EA-0113.yml
+++ b/osfv_cli/osfv_cli/models/EA-0113.yml
@@ -9,4 +9,4 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_state: "G3"

--- a/osfv_cli/osfv_cli/models/FW4C.yml
+++ b/osfv_cli/osfv_cli/models/FW4C.yml
@@ -11,7 +11,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR4.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR4.yml
@@ -8,4 +8,4 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
-  init_on: false
+  flashing_power_state: "OFF"

--- a/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR5.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z690-A DDR5.yml
@@ -8,4 +8,4 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
-  init_on: false
+  flashing_power_state: "OFF"

--- a/osfv_cli/osfv_cli/models/MSI PRO Z790-P WIFI DDR5.yml
+++ b/osfv_cli/osfv_cli/models/MSI PRO Z790-P WIFI DDR5.yml
@@ -8,4 +8,4 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
-  init_on: false
+  flashing_power_state: "OFF"

--- a/osfv_cli/osfv_cli/models/MinnowBoard Turbot B41.yml
+++ b/osfv_cli/osfv_cli/models/MinnowBoard Turbot B41.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 reset_cmos: false

--- a/osfv_cli/osfv_cli/models/V1210.yml
+++ b/osfv_cli/osfv_cli/models/V1210.yml
@@ -10,7 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/V1410.yml
+++ b/osfv_cli/osfv_cli/models/V1410.yml
@@ -10,7 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/V1610.yml
+++ b/osfv_cli/osfv_cli/models/V1610.yml
@@ -10,7 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP2410.yml
+++ b/osfv_cli/osfv_cli/models/VP2410.yml
@@ -14,7 +14,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: false
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP2420.yml
+++ b/osfv_cli/osfv_cli/models/VP2420.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
-  init_on: true
+  flashing_power_sate: "G3"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP4630.yml
+++ b/osfv_cli/osfv_cli/models/VP4630.yml
@@ -14,7 +14,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
-  init_on: true
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP4650.yml
+++ b/osfv_cli/osfv_cli/models/VP4650.yml
@@ -14,7 +14,7 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
-  init_on: true
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP4670.yml
+++ b/osfv_cli/osfv_cli/models/VP4670.yml
@@ -14,7 +14,7 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
-  init_on: true
+  flashing_power_state: "OFF"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP6650.yml
+++ b/osfv_cli/osfv_cli/models/VP6650.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
-  init_on: true
+  flashing_power_state: "OFF"
 
 reset_cmos: true

--- a/osfv_cli/osfv_cli/models/VP6670.yml
+++ b/osfv_cli/osfv_cli/models/VP6670.yml
@@ -9,6 +9,6 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
-  init_on: true
+  flashing_power_state: "OFF"
 
 reset_cmos: true


### PR DESCRIPTION
Fixes: https://github.com/Dasharo/osfv-scripts/issues/37
Fixes: https://github.com/Dasharo/osfv-scripts/issues/15

Tested:

* MSI Z690

DUT model retrieved from snipeit: MSI PRO Z690-A DDR4 Found Macronix flash chip "MX25U25635F" (32768 kB, SPI) on linux_spi.

* Protectli V1410

DUT model retrieved from snipeit: V1410
Found Winbond flash chip "W25Q128.V" (16384 kB, SPI) on ch341a_spi.

* Protectli VP6650

DUT model retrieved from snipeit: VP6650
Found Macronix flash chip "MX25L12833F/MX25L12835F/MX25L12845E/MX25L12865E/MX25L12873F" (16384 kB, SPI) on linux_spi.

* PC Engines APU3

DUT model retrieved from snipeit: APU3
Found Winbond flash chip "W25Q64JV-.Q" (8192 kB, SPI) on linux_spi.

* PC Engines APU4

DUT model retrieved from snipeit: APU4
Found Winbond flash chip "W25Q64JV-.Q" (8192 kB, SPI) on linux_spi.

* Protecli VP46XX - none in lab currently fully connected