### PR TITLE
osfv_cli/src/osfv/libs/rte.py: Change location of ROM file

### DIFF
--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -22,7 +22,7 @@ class RTE(rtectrl):
 
     SSH_USER = "root"
     SSH_PWD = "meta-rte"
-    FW_PATH_WRITE = "/tmp/write.rom"
+    FW_PATH_WRITE = "/data/write.rom"
     FW_PATH_READ = "/tmp/read.rom"
 
     PROGRAMMER_RTE = "linux_spi:dev=/dev/spidev1.0,spispeed=16000"


### PR DESCRIPTION
ROM sizes might reach 32MB, thus filling most of the usable RAM on OPi. Changing location of the to-be-written ROM from /tmp will prevent this.