### PR TITLE
rte: add PSU commands and documentation

### DIFF
--- a/osfv_cli/src/osfv/cli/cli.py
+++ b/osfv_cli/src/osfv/cli/cli.py
@@ -249,6 +249,12 @@ def relay_get(rte, args):
 
 
 def power_on(rte, args):
+    state = rte.psu_get()
+    if state != "on" or state != "ON":
+        print(f"Power supply state: {state} !")
+        print(
+            'If you wanted to power on the DUT, you need to enable power supply first ("pwr psu on"), pushing the power button is not enough!'
+        )
     print(f"Powering on...")
     rte.power_on(args.time)
 
@@ -261,6 +267,21 @@ def power_off(rte, args):
 def reset(rte, args):
     print(f"Pressing reset button...")
     rte.reset(args.time)
+
+
+def psu_on(rte, args):
+    print(f"Enabling power supply...")
+    rte.psu_on()
+
+
+def psu_off(rte, args):
+    print(f"Disabling power supply...")
+    rte.psu_off()
+
+
+def psu_get(rte, args):
+    state = rte.psu_get()
+    print(f"Power supply state: {state}")
 
 
 def gpio_get(rte, args):
@@ -663,27 +684,42 @@ def main():
 
     # Power subcommands
     pwr_subparsers = pwr_parser.add_subparsers(title="subcommands", dest="pwr_cmd")
-    power_on_parser = pwr_subparsers.add_parser("on", help="Power on")
+    power_on_parser = pwr_subparsers.add_parser(
+        "on", help="Short power button press, to power on DUT"
+    )
     power_on_parser.add_argument(
         "--time",
         type=int,
         default=1,
         help="Power button press time in seconds (default: 1)",
     )
-    power_off_parser = pwr_subparsers.add_parser("off", help="Power off")
+    power_off_parser = pwr_subparsers.add_parser(
+        "off", help="Long power button press, to power off DUT"
+    )
     power_off_parser.add_argument(
         "--time",
         type=int,
-        default=5,
-        help="Power button press time in seconds (default: 5)",
+        default=6,
+        help="Power button press time in seconds (default: 6)",
     )
-    reset_parser = pwr_subparsers.add_parser("reset", help="Reset")
+    reset_parser = pwr_subparsers.add_parser(
+        "reset", help="Reset button press, to reset DUT"
+    )
     reset_parser.add_argument(
         "--time",
         type=int,
         default=1,
         help="Reset button press time in seconds (default: 1)",
     )
+    psu_parser = pwr_subparsers.add_parser(
+        "psu", help="Generic control interface of the power supply"
+    )
+    psu_subparsers = psu_parser.add_subparsers(
+        title="Power supply commands", dest="psu_cmd"
+    )
+    psu_subparsers.add_parser("on", help="Turn the power supply on")
+    psu_subparsers.add_parser("off", help="Turn the power supply off")
+    psu_subparsers.add_parser("get", help="Display information on DUT's power state")
 
     # GPIO subcommands
     gpio_subparsers = gpio_parser.add_subparsers(title="subcommands", dest="gpio_cmd")
@@ -843,6 +879,13 @@ def main():
                 power_off(rte, args)
             elif args.pwr_cmd == "reset":
                 reset(rte, args)
+            elif args.pwr_cmd == "psu":
+                if args.psu_cmd == "on":
+                    psu_on(rte, args)
+                elif args.psu_cmd == "off":
+                    psu_off(rte, args)
+                elif args.psu_cmd == "get":
+                    psu_get(rte, args)
         elif args.rte_cmd == "serial":
             open_dut_serial(rte, args)
         elif args.rte_cmd == "spi":

--- a/osfv_cli/src/osfv/cli/cli.py
+++ b/osfv_cli/src/osfv/cli/cli.py
@@ -250,7 +250,7 @@ def relay_get(rte, args):
 
 def power_on(rte, args):
     state = rte.psu_get()
-    if state != "on" or state != "ON":
+    if state != rte.PSU_STATE_ON:
         print(f"Power supply state: {state} !")
         print(
             'If you wanted to power on the DUT, you need to enable power supply first ("pwr psu on"), pushing the power button is not enough!'

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -20,6 +20,9 @@ class RTE(rtectrl):
 
     GPIO_CMOS = 12
 
+    PSU_STATE_ON = "ON"
+    PSU_STATE_OFF = "OFF"
+
     SSH_USER = "root"
     SSH_PWD = "meta-rte"
     FW_PATH_WRITE = "/data/write.rom"
@@ -147,9 +150,9 @@ class RTE(rtectrl):
         gpio_state = self.gpio_get(self.GPIO_RELAY)
         relay_state = None
         if gpio_state == "high":
-            relay_state = "on"
+            relay_state = self.PSU_STATE_ON
         if gpio_state == "low":
-            relay_state = "off"
+            relay_state = self.PSU_STATE_OFF
         return relay_state
 
     def relay_set(self, relay_state):
@@ -161,9 +164,9 @@ class RTE(rtectrl):
                                or "off" (sets GPIO pin to "low").
         """
         gpio_state = None
-        if relay_state == "on":
+        if relay_state == self.PSU_STATE_ON:
             gpio_state = "high"
-        if relay_state == "off":
+        if relay_state == self.PSU_STATE_OFF:
             gpio_state = "low"
         self.gpio_set(self.GPIO_RELAY, gpio_state)
 
@@ -226,12 +229,12 @@ class RTE(rtectrl):
         if self.dut_data["pwr_ctrl"]["sonoff"] is True:
             self.sonoff.turn_off()
             state = self.sonoff.get_state()
-            if state != "OFF":
+            if state != self.PSU_STATE_OFF:
                 raise Exception("Failed to power control OFF")
         elif self.dut_data["pwr_ctrl"]["relay"] is True:
-            self.relay_set("off")
+            self.relay_set(self.PSU_STATE_OFF)
             state = self.relay_get()
-            if state != "off":
+            if state != self.PSU_STATE_OFF:
                 raise Exception("Failed to power control OFF")
         time.sleep(2)
 

--- a/osfv_cli/src/osfv/libs/rtectrl_api.py
+++ b/osfv_cli/src/osfv/libs/rtectrl_api.py
@@ -6,17 +6,51 @@ headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
 
 class rtectrl:
+    """
+    A class to control and interact with GPIO pins on an RTE device using its REST API.
+
+    Attributes:
+        GPIO_MIN (int): Minimum valid GPIO number (0).
+        GPIO_MAX (int): Maximum valid GPIO number (19).
+    """
+
     GPIO_MIN = 0
     GPIO_MAX = 19
 
     def __init__(self, rte_ip):
+        """
+        Initializes the `rtectrl` instance.
+
+        Args:
+            rte_ip (str): IP address of the RTE device.
+        """
+        self.rte_ip
         self.rte_ip = rte_ip
 
     def gpio_list(self):
+        """
+        Retrieves a list of all GPIO configurations from the RTE device.
+
+        Returns:
+            list: A JSON response containing details of all GPIO configurations.
+        """
         response = self._get_request(f"/gpio").json()
         return response
 
     def gpio_get(self, gpio_no):
+        """
+        Retrieves the state of a specific GPIO pin.
+
+        Args:
+            gpio_no (int): GPIO pin number to retrieve the state for.
+
+        Returns:
+            str: State of the GPIO pin. For pins 1-12: "low" or "high-z".
+                 For pins 0, 13-19: "high" or "low".
+
+        Raises:
+            GPIOWrongNumberError: If the GPIO number is outside the valid range.
+        """
         if not self.GPIO_MIN <= gpio_no <= self.GPIO_MAX:
             raise GPIOWrongNumberError("Wrong GPIO number")
 
@@ -39,6 +73,21 @@ class rtectrl:
         return state_str
 
     def gpio_set(self, gpio_no, state_str, sleep=0):
+        """
+        Sets the state of a specific GPIO pin.
+
+        Args:
+            gpio_no (int): GPIO pin number to set the state for.
+            state_str (str): Desired state for the GPIO pin.
+                             For pins 1-12: "low" or "high-z".
+                             For pins 0, 13-19: "high" or "low".
+            sleep (int, optional): Duration in seconds for which to maintain the state. Default is 0.
+
+        Raises:
+            GPIOWrongNumberError: If the GPIO number is outside the valid range.
+            GPIOWrongStateError: If an invalid GPIO state is provided.
+            RuntimeError: If the API request fails to set the GPIO state.
+        """
         if not self.GPIO_MIN <= gpio_no <= self.GPIO_MAX:
             raise GPIOWrongNumberError("Wrong GPIO number")
 
@@ -73,12 +122,37 @@ class rtectrl:
             print(f"Failed while setting gpio {e}")
 
     def _get_request(self, endpoint):
+        """
+        Sends a GET request to the specified API endpoint.
+
+        Args:
+            endpoint (str): API endpoint to send the GET request to.
+
+        Returns:
+            Response: The HTTP response object.
+
+        Raises:
+            HTTPError: If the response contains an HTTP error status code.
+        """
         url = BASE_URL_TEMPLATE.format(rte_ip=self.rte_ip)
         response = requests.get(f"{url}{endpoint}", headers=headers)
         response.raise_for_status()
         return response
 
     def _patch_request(self, endpoint, data):
+        """
+        Sends a PATCH request to the specified API endpoint with the provided data.
+
+        Args:
+            endpoint (str): API endpoint to send the PATCH request to.
+            data (dict): Data to include in the PATCH request body.
+
+        Returns:
+            Response: The HTTP response object.
+
+        Raises:
+            HTTPError: If the response contains an HTTP error status code.
+        """
         url = BASE_URL_TEMPLATE.format(rte_ip=self.rte_ip)
         response = requests.patch(f"{url}{endpoint}", json=data, headers=headers)
         response.raise_for_status()
@@ -86,8 +160,12 @@ class rtectrl:
 
 
 class GPIOWrongNumberError(Exception):
+    """Raised when an invalid GPIO number is provided."""
+
     pass
 
 
 class GPIOWrongStateError(Exception):
+    """Raised when an invalid GPIO state is provided."""
+
     pass

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -139,6 +139,20 @@ class RobotRTE:
         self.rte.reset(time)
 
     @keyword(types=None)
+    def rte_psu_on(self):
+        robot.api.logger.info(f"Enabling power supply...")
+        self.rte.psu_on()
+
+    @keyword(types=None)
+    def rte_psu_off(self):
+        robot.api.logger.info(f"Disabling power supply...")
+        self.rte.psu_off()
+
+    @keyword(types=None)
+    def rte_psu_get(self):
+        return self.rte.psu_get()
+
+    @keyword(types=None)
     def rte_gpio_get(self, gpio_no):
         state = self.rte.gpio_get(int(gpio_no))
         robot.api.logger.info(f"GPIO {gpio_no} state: {state}")


### PR DESCRIPTION
    Somehow fixes: https://github.com/Dasharo/osfv-scripts/issues/69
    
    I think in the end we do not need that much logic in this CLI tool, but
    the PSU control was definitely missing. We provide a single interface
    to control the PSU, no matter what power control (relay, Sonoff) is in
    place.
    
    It has been added and exposed to the OSFV via RF libs. The CLI tool
    should not know much about the firmware behavior, such as whether
    the DUT will power on when PSU is enabled, or not. This is often
    configurable, even at runtime, and should be handled in test environment
    instead. In many cases, the CLI tool may even ope