### PR TITLE
src/osfv/libs/rte.py: Add sleep in loop to avoid high CPU usage

### DIFF
--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -358,6 +358,9 @@ class RTE(rtectrl):
 
             # Print the command output in real-time
             while True:
+                # Sleep 100ms to prevent high CPU usage.
+                time.sleep(100 / 1000)
+
                 if channel.exit_status_ready():
                     break
                 if channel.recv_ready():


### PR DESCRIPTION
While flashing DUT, osfv_cli, in a loop, pulls data from DUT and prints it within the CLI. Add 100ms delay to the loop, to avoid high CPU usage. 100ms is arguably insignificant delay and does not impact the readability of the messages put in CLI.

Fixes https://github.com/Dasharo/osfv-scripts/issues/95