### PR TITLE
osfv_cli: string literals breaking fixed, source limited to 80 cols

### DIFF
--- a/osfv_cli/src/osfv/cli/cli.py
+++ b/osfv_cli/src/osfv/cli/cli.py
@@ -29,7 +29,8 @@ def check_out_asset(snipeit_api, asset_id):
         print(f"Error checking out asset {asset_id}")
         print(f"Response data: {data}")
         exit(
-            f"Exiting to avoid conflict. Check who is working on this device and contact them first."
+            f"Exiting to avoid conflict. Check who is working on this device"
+            f" and contact them first."
         )
 
     return already_checked_out
@@ -93,7 +94,8 @@ def list_my_assets(snipeit_api, args):
 
     Args:
         snipeit_api: The API client used to interact with the Snipe-IT API.
-        args: Command-line arguments object which contains the following attributes:
+        args: Command-line arguments object which contains the following
+              attributes:
             - json: A boolean indicating to output the list as json.
     Returns:
         Boolean: False if no assets were assigned to the user, True otherwise
@@ -119,7 +121,8 @@ def check_in_my(snipeit_api, args):
 
     Args:
         snipeit_api: The API client used to interact with the Snipe-IT API.
-        args: Command-line arguments object which contains the following attributes:
+        args: Command-line arguments object which contains the following
+              attributes:
             - yes: A boolean indicating to skip the confirmation prompt.
     Returns:
         None
@@ -200,7 +203,8 @@ def list_for_zabbix(snipeit_api, args):
 # Print asset details including custom fields
 def print_asset_details(asset):
     print(
-        f'Asset Tag: {asset["asset_tag"]}, Asset ID: {asset["id"]}, Name: {asset["name"]}, Serial: {asset["serial"]}'
+        f'Asset Tag: {asset["asset_tag"]}, Asset ID: {asset["id"]},'
+        f'Name: {asset["name"]}, Serial: {asset["serial"]}'
     )
 
     if asset["assigned_to"]:
@@ -265,7 +269,8 @@ def power_on(rte, args):
     if state != rte.PSU_STATE_ON:
         print(f"Power supply state: {state} !")
         print(
-            'If you wanted to power on the DUT, you need to enable power supply first ("pwr psu on"), pushing the power button is not enough!'
+            "If you wanted to power on the DUT, you need to enable power suppl"
+            'y first ("pwr psu on"), pushing the power button is not enough!'
         )
     print(f"Powering on...")
     rte.power_on(args.time)
@@ -507,12 +512,14 @@ def update_zabbix_assets(snipeit_api):
                 == snipeit_assets[snipeit_assets_keys[j]]
             ):
                 print(
-                    f"{snipeit_assets_keys[i]} has the same IP as {snipeit_assets_keys[j]}!"
+                    f"{snipeit_assets_keys[i]} has the same IP as "
+                    f"{snipeit_assets_keys[j]}!"
                 )
                 snipeit_configuration_error = True
             if snipeit_assets_keys[i] == snipeit_assets_keys[j]:
                 print(
-                    f"There are at least 2 assets with name {snipeit_assets_keys[i]} present!"
+                    f"There are at least 2 assets with name "
+                    f"{snipeit_assets_keys[i]} present!"
                 )
                 snipeit_configuration_error = True
 
@@ -521,7 +528,8 @@ def update_zabbix_assets(snipeit_api):
             symbol in snipeit_assets_keys[i] for symbol in forbidden_symbols
         ):
             print(
-                f"{snipeit_assets_keys[i]} contains forbidden symbols! They are going to be changed to '_'."
+                f"{snipeit_assets_keys[i]} contains forbidden symbols! They "
+                f"are going to be changed to '_'."
             )
             new_key = copy(snipeit_assets_keys[i])
             for s in forbidden_symbols:
@@ -533,7 +541,8 @@ def update_zabbix_assets(snipeit_api):
 
     if snipeit_configuration_error:
         print(
-            "\nSnipeIT configuration errors have been detected! Fix them and then continue."
+            "\nSnipeIT configuration errors have been detected! "
+            "Fix them and then continue."
         )
         return
 
@@ -561,7 +570,8 @@ def update_zabbix_assets(snipeit_api):
 
     if keys_not_present_in_snipeit.__len__() > 0:
         print(
-            "\nAssets present in Zabbix but not in SnipeIT (these will be removed):"
+            "\nAssets present in Zabbix but not in SnipeIT "
+            "(these will be removed):"
         )
         print("\n".join(keys_not_present_in_snipeit))
 
@@ -570,7 +580,8 @@ def update_zabbix_assets(snipeit_api):
     for key in common_keys:
         if snipeit_assets[key] != current_zabbix_assets[key]:
             print(
-                f"{key} has wrong IP! (Zabbix one will be updated from {current_zabbix_assets[key]} to {snipeit_assets[key]})"
+                f"{key} has wrong IP! (Zabbix one will be updated from "
+                f"{current_zabbix_assets[key]} to {snipeit_assets[key]})"
             )
             keys_for_ip_change.append(key)
 
@@ -750,8 +761,10 @@ def main():
     rte_parser.add_argument(
         "--skip-snipeit",
         action="store_true",
-        help="Skips Snipe-IT related actions like checkout and check-in. \
-            Useful for OSFV homelab.",
+        help=(
+            f"Skips Snipe-IT related actions like checkout and check-in. "
+            f"Useful for OSFV homelab."
+        ),
     )
     rte_subparsers = rte_parser.add_subparsers(
         title="subcommands", dest="rte_cmd", help="RTE subcommands"
@@ -983,7 +996,8 @@ def main():
                     )
                 else:
                     exit(
-                        f"failed to retrieve model name from snipe-it. check again arguments, or try providing model manually."
+                        f"failed to retrieve model name from snipe-it. check "
+                        f"again arguments, or try providing model manually."
                     )
             else:
                 exit(f"model name not present. check again arguments.")
@@ -992,7 +1006,8 @@ def main():
 
         if not args.skip_snipeit:
             print(
-                f"Using rte command is invasive action, checking first if the device is not used..."
+                f"Using rte command is invasive action, checking first if the "
+                f"device is not used..."
             )
             already_checked_out = check_out_asset(snipeit_api, asset_id)
 
@@ -1053,16 +1068,16 @@ def main():
         if not args.skip_snipeit:
             if already_checked_out:
                 print(
-                    f"Since the asset {asset_id} has been checkout manually \
-                    by you prior running this script, it will NOT be checked \
-                    in automatically. Please return the device when work is \
-                    finished."
+                    f"Since the asset {asset_id} has been checkout manually "
+                    f"by you prior running this script, it will NOT be checked "
+                    f"in automatically. Please return the device when work is "
+                    f"finished."
                 )
             else:
                 print(
-                    f"Since the asset {asset_id} has been checkout \
-                    automatically by this script, it is automatically checked \
-                    in as well."
+                    f"Since the asset {asset_id} has been checkout "
+                    f"automatically by this script, it is automatically "
+                    f"checked in as well."
                 )
                 check_in_asset(snipeit_api, asset_id)
     elif args.command == "sonoff":
@@ -1080,7 +1095,8 @@ def main():
             print(f"No asset found with RTE IP: {args.rte_ip}")
 
         print(
-            f"Using rte command is invasive action, checking first if the device is not used..."
+            f"Using rte command is invasive action, checking first if the "
+            f"device is not used..."
         )
         already_checked_out = check_out_asset(snipeit_api, asset_id)
 
@@ -1097,11 +1113,15 @@ def main():
 
         if already_checked_out:
             print(
-                f"Since the asset {asset_id} has been checkout manually by you prior running this script, it will NOT be checked in automatically. Please return the device when work is finished."
+                f"Since the asset {asset_id} has been checkout manually by "
+                f"you prior running this script, it will NOT be checked in "
+                f"automatically. Please return the device when work is "
+                f"finished."
             )
         else:
             print(
-                f"Since the asset {asset_id} has been checkout automatically by this script, it is automatically checked in as well."
+                f"Since the asset {asset_id} has been checkout automatically "
+                f"by this script, it is automatically checked in as well."
             )
             check_in_asset(snipeit_api, asset_id)
     elif args.command == "list_models":

--- a/osfv_cli/src/osfv/libs/models.py
+++ b/osfv_cli/src/osfv/libs/models.py
@@ -109,7 +109,8 @@ class Models:
                 else:
                     if exit_on_failure:
                         exit(
-                            f"Required field '{field}' is missing in model config."
+                            f"Required field '{field}' is missing in model "
+                            f"config."
                         )
                     else:
                         model_YML_status = False

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -46,7 +46,8 @@ class RTE(rtectrl):
         if not self.sonoff_sanity_check():
             raise SonoffNotFound(
                 exit(
-                    f"Missing value for 'sonoff_ip' or Sonoff not found in SnipeIT"
+                    f"Missing value for 'sonoff_ip' or Sonoff not found "
+                    f"in SnipeIT"
                 )
             )
 
@@ -104,11 +105,13 @@ class RTE(rtectrl):
 
     def relay_set(self, relay_state):
         """
-        Sets the state of the relay by configuring the GPIO relay pin accordingly.
+        Sets the state of the relay by configuring the GPIO relay pin
+        accordingly.
 
         Args:
-            relay_state (str): Desired state of the relay, either "on" (sets GPIO pin to "high")
-                               or "off" (sets GPIO pin to "low").
+            relay_state (str): Desired state of the relay, either "on"
+                               (sets GPIO pin to "high") or "off"
+                               (sets GPIO pin to "low").
         """
         gpio_state = None
         if relay_state == self.PSU_STATE_ON:
@@ -119,7 +122,8 @@ class RTE(rtectrl):
 
     def reset_cmos(self):
         """
-        Resets the CMOS by setting the GPIO CMOS pin to "low" for 10 seconds, then returning it to a "high-z" state.
+        Resets the CMOS by setting the GPIO CMOS pin to "low" for 10 seconds,
+         then returning it to a "high-z" state.
         """
         self.gpio_set(self.GPIO_CMOS, "low")
         time.sleep(10)
@@ -127,7 +131,8 @@ class RTE(rtectrl):
 
     def spi_enable(self):
         """
-        Enables the SPI interface by configuring GPIO pins based on the voltage level required by the flash chip.
+        Enables the SPI interface by configuring GPIO pins based on the voltage
+         level required by the flash chip.
         """
         voltage = self.dut_data["flash_chip"]["voltage"]
 
@@ -154,7 +159,8 @@ class RTE(rtectrl):
 
     def psu_on(self):
         """
-        Connect main power supply to the DUT by setting either relay or Sonoff to ON state.
+        Connect main power supply to the DUT by setting either relay
+        or Sonoff to ON state.
         """
         if self.dut_data["pwr_ctrl"]["sonoff"] is True:
             self.sonoff.turn_on()
@@ -170,7 +176,8 @@ class RTE(rtectrl):
 
     def psu_off(self):
         """
-        Disconnect main power supply from the DUT by setting either relay or Sonoff to OFF state.
+        Disconnect main power supply from the DUT by setting either relay
+        or Sonoff to OFF state.
         """
         # TODO: rework using abstract interfaces for power control?
         if self.dut_data["pwr_ctrl"]["sonoff"] is True:
@@ -198,14 +205,16 @@ class RTE(rtectrl):
 
     def discharge_psu(self):
         """
-        Push power button 5 times in the loop to make sure the charge from PSU is dissipated
+        Push power button 5 times in the loop to make sure the charge
+        from PSU is dissipated
         """
         for _ in range(5):
             self.power_off(3)
 
     def pwr_ctrl_before_flash(self, programmer, power_state):
         """
-        Move the DUT into specific power state required for external flashing operation. Defined in the model config file.
+        Move the DUT into specific power state required for external flashing
+        operation. Defined in the model config file.
         """
 
         # Always start from the same state (PSU active)
@@ -232,7 +241,8 @@ class RTE(rtectrl):
             self.discharge_psu()
         else:
             exit(
-                f"Power state: '{power_state}' is not supported. Please check model config."
+                f"Power state: '{power_state}' is not supported. Please check "
+                f"model config."
             )
 
     def pwr_ctrl_after_flash(self, programmer):
@@ -245,7 +255,8 @@ class RTE(rtectrl):
 
     def flash_cmd(self, args, read_file=None, write_file=None):
         """
-        Send the firmware file to RTE and execute flashrom command over SSH to flash the DUT.
+        Send the firmware file to RTE and execute flashrom command over SSH to
+        flash the DUT.
         """
         try:
             self.pwr_ctrl_before_flash(

--- a/osfv_cli/src/osfv/libs/rtectrl_api.py
+++ b/osfv_cli/src/osfv/libs/rtectrl_api.py
@@ -8,7 +8,8 @@ headers = {"Content-Type": "application/json", "Accept": "application/json"}
 
 class rtectrl:
     """
-    A class to control and interact with GPIO pins on an RTE device using its REST API.
+    A class to control and interact with GPIO pins on an RTE device
+    using its REST API.
 
     Attributes:
         GPIO_MIN (int): Minimum valid GPIO number (0).
@@ -82,7 +83,8 @@ class rtectrl:
             state_str (str): Desired state for the GPIO pin.
                              For pins 1-12: "low" or "high-z".
                              For pins 0, 13-19: "high" or "low".
-            sleep (int, optional): Duration in seconds for which to maintain the state. Default is 0.
+            sleep (int, optional): Duration in seconds for which to maintain the
+                                   state. Default is 0.
 
         Raises:
             GPIOWrongNumberError: If the GPIO number is outside the valid range.
@@ -146,7 +148,8 @@ class rtectrl:
 
     def _patch_request(self, endpoint, data):
         """
-        Sends a PATCH request to the specified API endpoint with the provided data.
+        Sends a PATCH request to the specified API endpoint with the
+        provided data.
 
         Args:
             endpoint (str): API endpoint to send the PATCH request to.

--- a/osfv_cli/src/osfv/libs/snipeit_api.py
+++ b/osfv_cli/src/osfv/libs/snipeit_api.py
@@ -66,7 +66,8 @@ class SnipeIT:
             raise ValueError("Incomplete API configuration in the YAML file")
         if not isinstance(cfg["user_id"], int):
             raise ValueError(
-                f'User ID configuration in the YAML file should be int: {cfg["user_id"]}'
+                f"User ID configuration in the YAML file should be int: "
+                f'{cfg["user_id"]}'
             )
 
         return cfg
@@ -91,7 +92,8 @@ class SnipeIT:
                 page += 1
             else:
                 print(
-                    f"Error retrieving assets. Status code: {response.status_code}"
+                    f"Error retrieving assets. Status code: "
+                    f"{response.status_code}"
                 )
                 print(response.json())
                 break
@@ -291,8 +293,9 @@ class SnipeIT:
         """
         Checks out an asset to the current user.
 
-        This method attempts to check out the specified asset to the user identified by `self.cfg_user_id`.
-        If the asset is already checked out to this user, the method will simply confirm this status.
+        This method attempts to check out the specified asset to the user
+        identified by `self.cfg_user_id`. If the asset is already checked out
+        to this user, the method will simply confirm this status.
         Otherwise, it will make an HTTP POST request to check out the asset.
 
         Parameters:
@@ -300,12 +303,16 @@ class SnipeIT:
 
         Returns:
         tuple:
-            bool: Indicates if the checkout operation was initiated (True) or not (False).
-            dict or None: The JSON response from the API if the checkout was initiated, otherwise None.
-            bool: Indicates if the asset was already checked out to the current user (True) or not (False).
+            bool: Indicates if the checkout operation was initiated (True)
+                  or not (False).
+            dict or None: The JSON response from the API if the checkout was
+                          initiated, otherwise None.
+            bool: Indicates if the asset was already checked out to the current
+                  user (True) or not (False).
 
         Raises:
-        requests.exceptions.RequestException: If the HTTP request to the API fails.
+        requests.exceptions.RequestException: If the HTTP request to the API
+                                              fails.
         """
         self.check_asset_for_ip_exclusivity_by_id(asset_id)
 
@@ -393,7 +400,8 @@ class SnipeIT:
             return None
         else:
             print(
-                f"Error retrieving companies. Status code: {response.status_code}"
+                f"Error retrieving companies. Status code: "
+                f"{response.status_code}"
             )
             print(response.json())
             return None
@@ -410,7 +418,8 @@ class SnipeIT:
             return None
         else:
             print(
-                f"Error retrieving user groups. Status code: {response.status_code}"
+                f"Error retrieving user groups. Status code: "
+                f"{response.status_code}"
             )
             print(response.json())
             return None
@@ -440,7 +449,8 @@ class SnipeIT:
                 page += 1
             else:
                 print(
-                    f"Error retrieving users. Status code: {response.status_code}"
+                    f"Error retrieving users. Status code: "
+                    f"{response.status_code}"
                 )
                 print(response.json())
                 break
@@ -456,7 +466,10 @@ class SnipeIT:
             return None
 
     def user_add(self, first_name, last_name, company_name):
-        email = f"{unidecode.unidecode(first_name.lower())}.{unidecode.unidecode(last_name.lower())}@3mdeb.com"
+        email = (
+            f"{unidecode.unidecode(first_name.lower())}."
+            f"{unidecode.unidecode(last_name.lower())}@3mdeb.com"
+        )
         username = (
             f"{first_name[0].lower()}{unidecode.unidecode(last_name.lower())}"
         )
@@ -479,8 +492,8 @@ class SnipeIT:
             print(f"Company {company_name} not found in Snipe-IT.")
             return
 
-        # For some reason, with our SnipeIT instance the group IT assignment does
-        # not work and we still need to do this manually...
+        # For some reason, with our SnipeIT instance the group IT assignment
+        # does not work and we still need to do this manually...
         data = {
             "first_name": first_name,
             "last_name": last_name,
@@ -518,7 +531,10 @@ class SnipeIT:
             print(response_json)
 
     def user_del(self, first_name, last_name):
-        email = f"{unidecode.unidecode(first_name.lower())}.{unidecode.unidecode(last_name.lower())}@3mdeb.com"
+        email = (
+            f"{unidecode.unidecode(first_name.lower())}."
+            f"{unidecode.unidecode(last_name.lower())}@3mdeb.com"
+        )
         username = (
             f"{first_name[0].lower()}{unidecode.unidecode(last_name.lower())}"
         )
@@ -541,6 +557,7 @@ class SnipeIT:
             print(f"User {username} deleted successfully!")
         else:
             print(
-                f"Failed to delete user {username}. Status code: {response.status_code}"
+                f"Failed to delete user {username}. Status code: "
+                f"{response.status_code}"
             )
             print(response_json)

--- a/osfv_cli/src/osfv/libs/zabbix.py
+++ b/osfv_cli/src/osfv/libs/zabbix.py
@@ -93,7 +93,8 @@ class Zabbix:
         result = response.json()
         if "result" in result and len(result["result"]) > 0:
             print(
-                f"A host with name '{host_name}' already exists. Skipping host creation."
+                f"A host with name '{host_name}' already exists. Skipping host "
+                f"creation."
             )
             return result["result"][0]["hostid"]
 
@@ -104,7 +105,8 @@ class Zabbix:
         result = response.json()
         if "result" in result and len(result["result"]) > 0:
             print(
-                f"A host with IP address '{ip_address}' already exists. Skipping host creation."
+                f"A host with IP address '{ip_address}' already exists. "
+                f"Skipping host creation."
             )
             return result["result"][0]["hostid"]
 

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -51,7 +51,8 @@ class RobotRTE:
                 )
             else:
                 raise AssertionError(
-                    f"Failed to retrieve model name from Snipe-IT. Check again arguments, or try providing model manually."
+                    f"Failed to retrieve model name from Snipe-IT. Check again "
+                    f"arguments, or try providing model manually."
                 )
             self.sonoff, self.sonoff_ip = utils.init_sonoff(
                 sonoff_ip, self.rte_ip, self.snipeit_api

--- a/osfv_cli/src/osfv/rf/snipeit_robot.py
+++ b/osfv_cli/src/osfv/rf/snipeit_robot.py
@@ -44,5 +44,6 @@ def snipeit_get_asset_model(rte_ip):
         return data
     else:
         raise AssertionError(
-            f"Error getting model name of asset: {asset_id}. Response data: {data}"
+            f"Error getting model name of asset: {asset_id}. "
+            f"Response data: {data}"
         )


### PR DESCRIPTION
Literals breaking with backslash fixed, string literals and comments limited to 80 columns, remaining black autoformatter hints applied.