### PR TITLE
.github/workflows/build.yaml: bump GH actions to current versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
@@ -32,7 +32,7 @@ jobs:
           cd osfv_cli; make
 
       - name: Upload pip package as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pip-package
           path: dist/*.tar.gz


### PR DESCRIPTION
Fixes every workflow failing due to deprecated checkout and upload-artifact versions: https://github.com/Dasharo/osfv-scripts/actions/runs/13572952959