### PR TITLE
src/osfv/libs/rte.py: Fix CMOS_CLR GPIO number

### DIFF
--- a/osfv_cli/pyproject.toml
+++ b/osfv_cli/pyproject.toml
@@ -10,7 +10,7 @@ robotframework = "^7.2"
 
 [tool.poetry]
 name = "osfv"
-version = "0.5.10"
+version = "0.5.11"
 description = "Open Source Firmware Validation Command Line Interface Tool"
 authors = ["Maciej Pijanowski <Maciej.Pijanowski@3mdeb.com>"]
 include = ["src/models/*.yml"]

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -20,7 +20,7 @@ class RTE(rtectrl):
     GPIO_RESET = 8
     GPIO_POWER = 9
 
-    GPIO_CMOS = 12
+    GPIO_CMOS = 11
 
     GPIO_PWR_LED = 13
 

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -172,6 +172,11 @@ class RobotRTE:
         return self.rte.psu_get()
 
     @keyword(types=None)
+    def rte_clear_cmos(self):
+        robot.api.logger.info(f"Clearing CMOS...")
+        self.rte.reset_cmos()
+
+    @keyword(types=None)
     def rte_gpio_get(self, gpio_no):
         state = self.rte.gpio_get(int(gpio_no))
         robot.api.logger.info(f"GPIO {gpio_no} state: {state}")


### PR DESCRIPTION
Per RteCtrl.cfg the CMOS CLR pin has ID 11:

{
    "id" : 11,
    "description" : "apu_clr_cmos",
    "direction" : "out",
    "init_value" : 0,
    "sys_gpio" : 412
},