### PR TITLE
Vp3210 rte relay

### DIFF
--- a/osfv_cli/pyproject.toml
+++ b/osfv_cli/pyproject.toml
@@ -10,7 +10,7 @@ robotframework = "^7.2"
 
 [tool.poetry]
 name = "osfv"
-version = "0.5.11"
+version = "0.5.12"
 description = "Open Source Firmware Validation Command Line Interface Tool"
 authors = ["Maciej Pijanowski <Maciej.Pijanowski@3mdeb.com>"]
 include = ["src/models/*.yml"]

--- a/osfv_cli/src/osfv/models/VP3210.yml
+++ b/osfv_cli/src/osfv/models/VP3210.yml
@@ -11,7 +11,7 @@ programmer:
 
 pwr_ctrl:
   # whether power is controlled via Sonoff plug (required)
-  sonoff: true
+  sonoff: false
   # whether power is controller via on-board RTE relay (required)
-  relay: false
+  relay: true
   flashing_power_state: "G3"


### PR DESCRIPTION
The VP3230 uses 90W (12V 7.5A) PSU, which requires sonoff, but VP3210 uses 60W (12V 5A) PSU which is still suitable for RTE relay power control.

Additionally, using Sonoff with this 60W PSu caused the platform to not react to AC loss and did not power on automatically, despite configured to do so. It occurred that the PSU has quite high capacitance, which caused the PSU to supply 12V for a longer period of time after sonoff was toggled off. It could even partially power the RTE itself through the pins connected to DUT (the LEDs on RTE HAT were lit, despite microUSB power supply for RTE was disconnected).
 
The platform configs in OSFV test repo were set to use relay, despite it had a sonoff connected. it could be a cause of issues in the robot tests as well. However, above observation with the capacitance was made with direct visual confirmation without automation in robot.
