### PR TITLE
osfv_cli/src/osfv: Integrate power LED in power control

### DIFF
--- a/osfv_cli/src/osfv/cli/cli.py
+++ b/osfv_cli/src/osfv/cli/cli.py
@@ -281,28 +281,6 @@ def power_off(rte, args):
     rte.power_off(args.time)
 
 
-def power_on_ex(rte, args):
-    power_on(rte, args)
-    for attempt in range(20):
-        if check_pwr_led(rte, args) == "high":
-            print("Power on successful.")
-            return True
-        sleep(0.25)
-    print("Power on failed.")
-    return False
-
-
-def power_off_ex(rte, args):
-    power_off(rte, args)
-    for attempt in range(20):
-        if check_pwr_led(rte, args) == "low":
-            print("Power off successful.")
-            return True
-        sleep(0.25)
-    print("Power off failed.")
-    return False
-
-
 def reset(rte, args):
     print(f"Pressing reset button...")
     rte.reset(args.time)
@@ -797,30 +775,11 @@ def main():
         default=1,
         help="Power button press time in seconds (default: 1)",
     )
-    power_on_ex_parser = pwr_subparsers.add_parser(
-        "on_ex", help="Short power button press, to power on DUT"
-    )
-    power_on_ex_parser.add_argument(
-        "--time",
-        type=int,
-        default=1,
-        help="Power button press time in seconds (default: 1) AND verify if power LED did light up",
-    )
 
     power_off_parser = pwr_subparsers.add_parser(
         "off_ex", help="Long power button press, to power off DUT"
     )
     power_off_parser.add_argument(
-        "--time",
-        type=int,
-        default=6,
-        help="Power button press time in seconds (default: 6)",
-    )
-    power_off_ex_parser = pwr_subparsers.add_parser(
-        "off",
-        help="Long power button press, to power off DUT and verify if power LED did turn off",
-    )
-    power_off_ex_parser.add_argument(
         "--time",
         type=int,
         default=6,
@@ -1033,10 +992,6 @@ def main():
                 power_on(rte, args)
             elif args.pwr_cmd == "off":
                 power_off(rte, args)
-            if args.pwr_cmd == "on_ex":
-                power_on_ex(rte, args)
-            elif args.pwr_cmd == "off_ex":
-                power_off_ex(rte, args)
             elif args.pwr_cmd == "reset":
                 reset(rte, args)
             elif args.pwr_cmd == "pwr_led":

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -61,7 +61,14 @@ class RTE(rtectrl):
             power pin in the "low" state. Default is 1 second.
         """
         self.gpio_set(self.GPIO_POWER, "low", sleep)
-        time.sleep(sleep)
+        if self.dut_data['pwr_ctrl']['power_led'] is True:
+            for attempt in range(float(sleep) / 0.25):
+                if self.gpio_get(self.GPIO_PWR_LED) == "high":
+                    return True
+                time.sleep(0.25)
+            return False
+        else:
+            time.sleep(sleep)
 
     def power_off(self, sleep=6):
         """
@@ -73,7 +80,15 @@ class RTE(rtectrl):
             pin in the "low" state. Default is 6 seconds.
         """
         self.gpio_set(self.GPIO_POWER, "low", sleep)
-        time.sleep(sleep)
+        if self.dut_data['pwr_ctrl']['power_led'] is True:
+            for attempt in range(float(sleep) / 0.25):
+                if self.gpio_get(self.GPIO_PWR_LED) == "low":
+                    self.gpio_set(self.GPIO_POWER, "high", 0)
+                    return True
+                time.sleep(0.25)
+            return False
+        else:
+            time.sleep(sleep)
 
     def reset(self, sleep=1):
         """

--- a/osfv_cli/src/osfv/models/APU2.yml
+++ b/osfv_cli/src/osfv/models/APU2.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/APU3.yml
+++ b/osfv_cli/src/osfv/models/APU3.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/APU4.yml
+++ b/osfv_cli/src/osfv/models/APU4.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/APU5.yml
+++ b/osfv_cli/src/osfv/models/APU5.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/APU6.yml
+++ b/osfv_cli/src/osfv/models/APU6.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/APU7.yml
+++ b/osfv_cli/src/osfv/models/APU7.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "S5"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/EA-0113.yml
+++ b/osfv_cli/src/osfv/models/EA-0113.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: false
   flashing_power_state: "S5"
 
 disable_wp: true

--- a/osfv_cli/src/osfv/models/FW4C.yml
+++ b/osfv_cli/src/osfv/models/FW4C.yml
@@ -11,6 +11,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: false
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/H4-PLUS.yml
+++ b/osfv_cli/src/osfv/models/H4-PLUS.yml
@@ -8,6 +8,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: false
   flashing_power_state: "G3"
 
 reset_cmos: false

--- a/osfv_cli/src/osfv/models/MSI PRO Z690-A DDR4.yml
+++ b/osfv_cli/src/osfv/models/MSI PRO Z690-A DDR4.yml
@@ -8,4 +8,5 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
+  power_led: false
   flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/MSI PRO Z690-A DDR5.yml
+++ b/osfv_cli/src/osfv/models/MSI PRO Z690-A DDR5.yml
@@ -8,4 +8,5 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
+  power_led: false
   flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/MSI PRO Z790-P WIFI DDR5.yml
+++ b/osfv_cli/src/osfv/models/MSI PRO Z790-P WIFI DDR5.yml
@@ -8,4 +8,5 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
+  power_led: false
   flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/MinnowBoard Turbot B41.yml
+++ b/osfv_cli/src/osfv/models/MinnowBoard Turbot B41.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: false
   flashing_power_state: "G3"
 
 reset_cmos: false

--- a/osfv_cli/src/osfv/models/Optiplex 7010.yml
+++ b/osfv_cli/src/osfv/models/Optiplex 7010.yml
@@ -14,6 +14,7 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
+  power_led: false
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/V1210.yml
+++ b/osfv_cli/src/osfv/models/V1210.yml
@@ -10,6 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/V1410.yml
+++ b/osfv_cli/src/osfv/models/V1410.yml
@@ -10,6 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/V1610.yml
+++ b/osfv_cli/src/osfv/models/V1610.yml
@@ -10,6 +10,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/VP2410.yml
+++ b/osfv_cli/src/osfv/models/VP2410.yml
@@ -14,6 +14,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/VP2420.yml
+++ b/osfv_cli/src/osfv/models/VP2420.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/VP2430.yml
+++ b/osfv_cli/src/osfv/models/VP2430.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: false
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/VP3210.yml
+++ b/osfv_cli/src/osfv/models/VP3210.yml
@@ -14,4 +14,5 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/VP3230.yml
+++ b/osfv_cli/src/osfv/models/VP3230.yml
@@ -14,4 +14,5 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
+  power_led: true
   flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/VP4630.yml
+++ b/osfv_cli/src/osfv/models/VP4630.yml
@@ -14,6 +14,7 @@ pwr_ctrl:
   sonoff: false
   # whether power is controller via on-board RTE relay (required)
   relay: true
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/VP4650.yml
+++ b/osfv_cli/src/osfv/models/VP4650.yml
@@ -14,6 +14,7 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/VP4670.yml
+++ b/osfv_cli/src/osfv/models/VP4670.yml
@@ -14,6 +14,7 @@ pwr_ctrl:
   sonoff: true
   # whether power is controller via on-board RTE relay (required)
   relay: false
+  power_led: true
   flashing_power_state: "G3"
 
 # whether CMOS reset is required after flashing (optional - defaults to false)

--- a/osfv_cli/src/osfv/models/VP6650.yml
+++ b/osfv_cli/src/osfv/models/VP6650.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
+  power_led: true
   flashing_power_state: "G3"
 
 reset_cmos: true

--- a/osfv_cli/src/osfv/models/VP6670.yml
+++ b/osfv_cli/src/osfv/models/VP6670.yml
@@ -9,6 +9,7 @@ programmer:
 pwr_ctrl:
   sonoff: true
   relay: false
+  power_led: true
   flashing_power_state: "G3"
 
 reset_cmos: true


### PR DESCRIPTION
There is no need to have power_on_ex and power_off_ex keywords. Add a new atribute to YAML called power_led which inidcates whether the platform support checking the power LED. Use it to verify the state of the platform when using regualr power_on and power_off functions.