### PR TITLE
rte_robot.py: Make RobotRTE lib global

### DIFF
--- a/osfv_cli/README.md
+++ b/osfv_cli/README.md
@@ -283,10 +283,11 @@ The tests are written in [Robot Framework](https://robotframework.org/),
 
 ### Dependencies
 
-Install the dependencies:
+Enter development shell with test dependencies:
 
 ```shell
-pip install -r requirements.txt
+poetry install --with test
+poetry shell
 ```
 
 ### Required configs

--- a/osfv_cli/README.md
+++ b/osfv_cli/README.md
@@ -275,3 +275,33 @@ unset SSH_AUTH_SOCK
 
 You can test local changes by running `poetry shell` first. Then, all
 `osfv_cli` calls will use the local files in repository, not installed package.
+
+## Tests
+
+OSFV CLI tests can be found in the `test` directory.
+The tests are written in [Robot Framework](https://robotframework.org/),
+
+### Dependencies
+
+Install the dependencies:
+
+```shell
+pip install -r requirements.txt
+```
+
+### Required configs
+
+To test some functionalities related to SnipeIT, it is required to
+use a configuration of a second SnipeIT user. The configuration
+should be located at `~/.osfv-robot/snipeit.yaml`.
+The API key and User ID must be valid, and different
+from the one at `~/.osfv/snipeit.yaml`.
+For details on SnipeIT configuration see [Customize the configuration](#customize-the-configuration).
+
+### Running tests
+
+When all the prerequisites are met, the test can be run:
+
+```shell
+robot test
+```

--- a/osfv_cli/pyproject.toml
+++ b/osfv_cli/pyproject.toml
@@ -10,7 +10,7 @@ robotframework = "^7.2"
 
 [tool.poetry]
 name = "osfv"
-version = "0.5.14"
+version = "0.6.0"
 description = "Open Source Firmware Validation Command Line Interface Tool"
 authors = ["Maciej Pijanowski <Maciej.Pijanowski@3mdeb.com>"]
 include = ["src/models/*.yml"]

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -4,7 +4,7 @@ from osfv.libs.models import UnsupportedDUTModel
 from osfv.libs.rte import RTE
 from osfv.libs.snipeit_api import SnipeIT
 from osfv.libs.sonoff_api import SonoffDevice
-from robot.api.deco import keyword
+from robot.api.deco import keyword, library
 
 model_dict = {
     "odroid-h4-plus": "H4-PLUS",
@@ -41,6 +41,7 @@ model_dict = {
 }
 
 
+@library(scope="GLOBAL")
 class RobotRTE:
     def __init__(self, rte_ip, snipeit: bool, sonoff_ip=None, config=None):
         self.rte_ip = rte_ip


### PR DESCRIPTION
Otherwise RF calls __init__ on every keyword call instead of only once per run.

Should work according to https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#library-scope but it wasn't tested yet