### PR TITLE
Gigabyte mz33

### DIFF
--- a/osfv_cli/pyproject.toml
+++ b/osfv_cli/pyproject.toml
@@ -10,7 +10,7 @@ robotframework = "^7.2"
 
 [tool.poetry]
 name = "osfv"
-version = "0.7.3"
+version = "0.8.0"
 description = "Open Source Firmware Validation Command Line Interface Tool"
 authors = ["Maciej Pijanowski <Maciej.Pijanowski@3mdeb.com>"]
 include = ["src/models/*.yml"]

--- a/osfv_cli/pyproject.toml
+++ b/osfv_cli/pyproject.toml
@@ -10,7 +10,7 @@ robotframework = "^7.2"
 
 [tool.poetry]
 name = "osfv"
-version = "0.8.0"
+version = "0.8.1"
 description = "Open Source Firmware Validation Command Line Interface Tool"
 authors = ["Maciej Pijanowski <Maciej.Pijanowski@3mdeb.com>"]
 include = ["src/models/*.yml"]

--- a/osfv_cli/src/osfv/cli/cli.py
+++ b/osfv_cli/src/osfv/cli/cli.py
@@ -517,6 +517,13 @@ def gpio_get(rte, args):
 
 def check_pwr_led(rte, args):
     state = rte.gpio_get(RTE.GPIO_PWR_LED)
+    polarity = rte.dut_data.get("pwr_led", {}).get("polarity")
+    if polarity and polarity == "active low":
+        if state == "high":
+            state = "low"
+        else:
+            state = "high"
+
     print(f"Power LED state: {'ON' if state == 'high' else 'OFF'}")
     return state
 

--- a/osfv_cli/src/osfv/libs/models.py
+++ b/osfv_cli/src/osfv/libs/models.py
@@ -60,6 +60,7 @@ class Models:
             "rte_1_1", "rte_1_0", "ch341a", "dediprog"
         )
         flashing_power_state_validator = Any("G3", "S5")
+        pwr_led_validator = Any("active low", "active high")
 
         schema = Schema(
             {
@@ -82,6 +83,9 @@ class Models:
                     Required(
                         "flashing_power_state"
                     ): flashing_power_state_validator,
+                },
+                Optional("pwr_led"): {
+                    Required("polarity"): pwr_led_validator,
                 },
                 Optional("reset_cmos", default=False): bool,
                 Optional("disable_wp", default=False): bool,

--- a/osfv_cli/src/osfv/libs/models.py
+++ b/osfv_cli/src/osfv/libs/models.py
@@ -69,6 +69,12 @@ class Models:
                 Required("flash_chip"): {
                     Required("voltage"): voltage_validator,
                     Optional("model"): str,
+                    Optional("layout"): [
+                        {
+                            Required("name"): str,
+                            Required("range"): str,
+                        }
+                    ],
                 },
                 Required("pwr_ctrl"): {
                     Required("sonoff"): bool,

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -384,13 +384,14 @@ class RTE(rtectrl):
 
             scp = ssh.open_sftp()
 
-            # Transfer layout file if needed
+            # Transfer layout file if needed (only for write operations)
             layout_data = self.dut_data.get("flash_chip", {}).get("layout")
-            if layout_data:
+            if layout_data and write_file:
                 local_layout_path = self.create_layout_file()
                 remote_layout_path = self.FLASHROM_LAYOUT_PATH
                 scp.put(local_layout_path, remote_layout_path)
                 print(f"Layout file transferred to {remote_layout_path}")
+                os.remove(local_layout_path)
 
             # Transfer firmware file if provided
             if write_file:
@@ -539,17 +540,15 @@ class RTE(rtectrl):
             self.flash_cmd(args)
 
         # Check if this board needs layout file (from model file)
-        use_layout = self.dut_data.get("flash_chip", {}).get(
-            "use_layout", False
-        )
+        use_layout = self.dut_data.get("flash_chip", {}).get("layout", False)
 
         if use_layout:
             args = self.flash_create_args(
-                f"-i -N bios -w {self.FW_PATH_WRITE} --layout {self.FLASHROM_LAYOUT_PATH}"
+                f"-i bios -N -w {self.FW_PATH_WRITE} --layout {self.FLASHROM_LAYOUT_PATH}"
             )
         elif bios:
             args = self.flash_create_args(
-                f"-i -N bios --ifd -w {self.FW_PATH_WRITE}"
+                f"-i bios -N --ifd -w {self.FW_PATH_WRITE}"
             )
         else:
             args = self.flash_create_args(f"-w {self.FW_PATH_WRITE}")

--- a/osfv_cli/src/osfv/libs/rte.py
+++ b/osfv_cli/src/osfv/libs/rte.py
@@ -544,7 +544,6 @@ class RTE(rtectrl):
         )
 
         if use_layout:
-            # New motherboard with layout file support
             args = self.flash_create_args(
                 f"-i -N bios -w {self.FW_PATH_WRITE} --layout {self.FLASHROM_LAYOUT_PATH}"
             )

--- a/osfv_cli/src/osfv/models/MZ33-AR1 Rev. 3.yml
+++ b/osfv_cli/src/osfv/models/MZ33-AR1 Rev. 3.yml
@@ -1,0 +1,16 @@
+---
+flash_chip:
+  voltage: "3.3V"
+  layout:
+    - name: "reserved"
+      range: "00000000:01cbffff"
+    - name: "bios"
+      range: "01cc0000:01ffffff"
+
+programmer:
+  name: rte_1_1
+
+pwr_ctrl:
+  sonoff: true
+  relay: false
+  flashing_power_state: "G3"

--- a/osfv_cli/src/osfv/models/MZ33-AR1 Rev. 3.yml
+++ b/osfv_cli/src/osfv/models/MZ33-AR1 Rev. 3.yml
@@ -14,3 +14,6 @@ pwr_ctrl:
   sonoff: true
   relay: false
   flashing_power_state: "G3"
+
+pwr_led:
+  polarity: "active low"

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -9,6 +9,7 @@ from robot.api.deco import keyword, library
 model_dict = {
     "odroid-h4-plus": "H4-PLUS",
     "odroid-h4-ultra": "H4-ULTRA",
+    "gigabyte-mz33-ar1": "MZ33-AR1 Rev. 3",
     "minnowboard-turbot": "MinnowBoard Turbot B41",
     "msi-pro-z690-a-ddr4": "MSI PRO Z690-A DDR4",
     "msi-pro-z690-a-wifi-ddr4": "MSI PRO Z690-A DDR4",

--- a/osfv_cli/src/osfv/rf/rte_robot.py
+++ b/osfv_cli/src/osfv/rf/rte_robot.py
@@ -345,6 +345,13 @@ class RobotRTE:
     @keyword(types=None)
     def rte_check_power_led(self):
         state = self.rte.gpio_get(RTE.GPIO_PWR_LED)
+        polarity = self.dut_data.get("pwr_led", {}).get("polarity")
+        if polarity and polarity == "active low":
+            if state == "high":
+                state = "low"
+            else:
+                state = "high"
+
         robot.api.logger.info(
             f"Power LED state: {'ON' if state == 'high' else 'OFF'}"
         )


### PR DESCRIPTION
Contrary to what https://github.com/Dasharo/docs/pull/1107 is suggesting, I am able to use this version to reliably flash the board. I think we can safely use `osfv_cli` with RTE for flashing it.


```
(osfv-py3.13) macpijan in ~/projects/github/dasharo/osfv-scripts/osfv_cli on gigabyte-mz33 ● λ osfv_cli rte --rte_ip 192.168.10.71 flash write --rom read.rom -x
DUT model retrieved from snipeit: MZ33-AR1 Rev. 3
Using rte command is invasive action, checking first if the device is not used...
Asset 257 is already checked out by you
Verifying flash image completeness of read.rom ...
Invalid image, no FLVALSIG found!
Failed to load image file. Cannot verify the presence of Intel regions.
Writing read.rom to flash...
Layout file transferred to /tmp/board_layout.txt
Executing command: flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000  -w /data/write.rom
flashrom 1.4.0 on Linux 6.6.28 (armv7l)
flashrom is free software, get the source code at https://flashrom.org

Found Macronix flash chip "MX25L25635F/MX25L25645G" (32768 kB, SPI) on linux_spi.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
Reading old flash chip contents... done.
Erase/write done from 0 to 1ffffff
Verifying flash... VERIFIED.
Flash written successfully
Since the asset 257 has been checkout manually by you prior running this script, it will NOT be checked in automatically. Please return the device when work is finished.
(osfv-py3.13) macpijan in ~/projects/github/dasharo/osfv-scripts/osfv_cli on gigabyte-mz33 ● λ osfv_cli rte --rte_ip 192.168.10.71 flash write --rom dump.bin -x 
DUT model retrieved from snipeit: MZ33-AR1 Rev. 3
Using rte command is invasive action, checking first if the device is not used...
Asset 257 is already checked out by you
Verifying flash image completeness of dump.bin ...
Invalid image, no FLVALSIG found!
Failed to load image file. Cannot verify the presence of Intel regions.
Writing dump.bin to flash...
Layout file transferred to /tmp/board_layout.txt
Executing command: flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000  -w /data/write.rom
flashrom 1.4.0 on Linux 6.6.28 (armv7l)
flashrom is free software, get the source code at https://flashrom.org

Found Macronix flash chip "MX25L25635F/MX25L25645G" (32768 kB, SPI) on linux_spi.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
Reading old flash chip contents... done.
Erase/write done from 0 to 1ffffff
Verifying flash... VERIFIED.
Flash written successfully
Since the asset 257 has been checkout manually by you prior running this script, it will NOT be checked in automatically. Please return the device when work is finished.
(osfv-py3.13) macpijan in ~/projects/github/dasharo/osfv-scripts/osfv_cli on gigabyte-mz33 ● λ osfv_cli rte --rte_ip 192.168.10.71 flash write --rom read.rom -x
DUT model retrieved from snipeit: MZ33-AR1 Rev. 3
Using rte command is invasive action, checking first if the device is not used...
Asset 257 is already checked out by you
Verifying flash image completeness of read.rom ...
Invalid image, no FLVALSIG found!
Failed to load image file. Cannot verify the presence of Intel regions.
Writing read.rom to flash...
Layout file transferred to /tmp/board_layout.txt
Executing command: flashrom -p linux_spi:dev=/dev/spidev1.0,spispeed=16000  -w /data/write.rom
flashrom 1.4.0 on Linux 6.6.28 (armv7l)
flashrom is free software, get the source code at https://flashrom.org

Found Macronix flash chip "MX25L25635F/MX25L25645G" (32768 kB, SPI) on linux_spi.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
Reading old flash chip contents... done.
Erase/write done from 0 to 1ffffff
Verifying flash... VERIFIED.
Flash written successfully
Since the asset 257 has been checkout manually by you prior running this script, it will NOT be checked in automatically. Please return the device when work is finished.
```